### PR TITLE
Fix misleading resource link text on Resources page

### DIFF
--- a/website/resources.html
+++ b/website/resources.html
@@ -23,11 +23,11 @@
 
 <section class="container">
     <h1>Resources</h1>
-    <p>Download our whitepapers, policy briefs, and media appearances. Stay tuned for upcoming webinars and training sessions.</p>
+    <p>Our downloadable whitepapers, policy briefs, and media kits are coming soon. In the meantime, explore these related pages:</p>
     <ul>
-        <li><a href="about.html">Presentation Slides</a></li>
-        <li><a href="compliance.html">Legislation PDF</a></li>
-        <li><a href="ai-infrastructure.html">Video Tutorials</a></li>
+        <li><a href="about.html">Company Overview</a></li>
+        <li><a href="compliance.html">Compliance Overview</a></li>
+        <li><a href="ai-infrastructure.html">AI Infrastructure Overview</a></li>
     </ul>
 </section>
 


### PR DESCRIPTION
### Motivation
- Replace misleading downloadable-asset labels on the Resources page because the links pointed to informational pages and created a confusing UX.

### Description
- Update `website/resources.html` to change the intro copy to indicate downloads are "coming soon" and rename three list items (Presentation Slides -> Company Overview, Legislation PDF -> Compliance Overview, Video Tutorials -> AI Infrastructure Overview) while keeping the same `href`s.

### Testing
- Parsed `website/resources.html` with Python's `html.parser` to validate the edited HTML and the parse succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d344c9d838832c91113496b6347ddc)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: purely static copy/link-text updates on a single HTML page with no functional or data-handling changes.
> 
> **Overview**
> Updates the `Resources` page to remove misleading “download” messaging by stating resource downloads are *coming soon*.
> 
> Renames the three existing resource links to reflect that they point to informational overview pages (company, compliance, and AI infrastructure) while keeping the same destinations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c650d8456e713667bc2de6e1e10884012764b32c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->